### PR TITLE
DERP-2027: Check item before getting image_url

### DIFF
--- a/bynder_local.module
+++ b/bynder_local.module
@@ -30,7 +30,7 @@ function bynder_local_media_presave(MediaInterface $media) {
   if ($source instanceof Bynder && $media->hasField($local_field) && !$media->get($local_field)->entity) {
     $source->ensureMetadata($media);
     $item = Json::decode($media->get(BynderMetadataItem::METADATA_FIELD_NAME)->value);
-    $image_url = bynder_local_get_image_url($item);
+    $image_url = $item ? bynder_local_get_image_url($item) : NULL;
 
     if (!$image_url) {
       Drupal::logger('bynder_local')


### PR DESCRIPTION
If the file field on a media entity isn't required, the module is currently trying to pass NULL into `bynder_get_local_image_url()`.

This checks that value before passing, and falls back to NULL for the image_url if `$item` is NULL.